### PR TITLE
Fix minify bugs and add robust CI/CD pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "chris-short"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "chris-short"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -34,7 +34,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache Cargo dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -51,7 +51,7 @@ jobs:
         run: cargo clippy -- -D warnings
 
       - name: Security audit
-        uses: rustsec/audit-check@v1
+        uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -95,7 +95,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -103,7 +103,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Cache Cargo dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -134,7 +134,7 @@ jobs:
              artifacts/rust-minifier-${{ matrix.target }}${{ matrix.binary_suffix }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rust-minifier-${{ matrix.target }}
           path: artifacts/
@@ -148,13 +148,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts/
           merge-multiple: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,22 +1,178 @@
-name: Rust
+---
+name: Release
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  ci:
+    name: CI
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Security audit
+        uses: rustsec/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build
+        run: cargo build --release
+
+      - name: Run tests
+        run: cargo test --verbose
+
+      - name: Smoke test
+        run: ./target/release/rust-minifier src/ --lang rust
+
+  build:
+    name: Build (${{ matrix.target }})
+    needs: ci
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            binary_suffix: ""
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            binary_suffix: ""
+            use_cross: true
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            binary_suffix: ""
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            binary_suffix: ""
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            binary_suffix: ".exe"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install cross
+        if: matrix.use_cross == true
+        run: cargo install cross
+
+      - name: Build release binary
+        shell: bash
+        run: |
+          if [ "${{ matrix.use_cross }}" = "true" ]; then
+            cross build --release --target ${{ matrix.target }}
+          else
+            cargo build --release --target ${{ matrix.target }}
+          fi
+
+      - name: Stage artifact
+        shell: bash
+        run: |
+          mkdir -p artifacts
+          cp target/${{ matrix.target }}/release/rust-minifier${{ matrix.binary_suffix }} \
+             artifacts/rust-minifier-${{ matrix.target }}${{ matrix.binary_suffix }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-minifier-${{ matrix.target }}
+          path: artifacts/
+
+  release:
+    name: Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts/
+          merge-multiple: true
+
+      - name: Generate and push version tag
+        id: tag
+        run: |
+          VERSION="v0.$(date +'%Y%m%d').${{ github.run_number }}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$VERSION"
+          git push origin "$VERSION"
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.version }}
+          name: ${{ steps.tag.outputs.version }}
+          files: artifacts/*
+          generate_release_notes: true

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
-use std::fs;
-use std::env;
-use std::path::Path;
 use std::collections::HashMap;
-use walkdir::{WalkDir, DirEntry};
+use std::env;
+use std::fs;
+use std::path::Path;
+use walkdir::{DirEntry, WalkDir};
 
 struct Language {
     extensions: Vec<String>,
@@ -17,12 +17,17 @@ fn get_language_config(lang: &str) -> Option<Language> {
         // 1. Python
         "python" => Some(Language {
             extensions: vec!["py".to_string(), "pyw".to_string()],
-            default_skip_dirs: vec!["__pycache__".to_string(), "venv".to_string(), ".env".to_string(), "dist".to_string()],
+            default_skip_dirs: vec![
+                "__pycache__".to_string(),
+                "venv".to_string(),
+                ".env".to_string(),
+                "dist".to_string(),
+            ],
             line_comment: "#".to_string(),
             block_comment_start: "'''".to_string(),
             block_comment_end: "'''".to_string(),
         }),
-        
+
         // 2. Java
         "java" => Some(Language {
             extensions: vec!["java".to_string()],
@@ -31,34 +36,50 @@ fn get_language_config(lang: &str) -> Option<Language> {
             block_comment_start: "/*".to_string(),
             block_comment_end: "*/".to_string(),
         }),
-        
+
         // 3. JavaScript
         "javascript" | "js" => Some(Language {
             extensions: vec!["js".to_string(), "jsx".to_string(), "mjs".to_string()],
-            default_skip_dirs: vec!["node_modules".to_string(), "dist".to_string(), "build".to_string()],
+            default_skip_dirs: vec![
+                "node_modules".to_string(),
+                "dist".to_string(),
+                "build".to_string(),
+            ],
             line_comment: "//".to_string(),
             block_comment_start: "/*".to_string(),
             block_comment_end: "*/".to_string(),
         }),
-        
+
         // 4. C++
         "cpp" | "c++" => Some(Language {
-            extensions: vec!["cpp".to_string(), "hpp".to_string(), "cc".to_string(), "hh".to_string(), "cxx".to_string(), "hxx".to_string()],
+            extensions: vec![
+                "cpp".to_string(),
+                "hpp".to_string(),
+                "cc".to_string(),
+                "hh".to_string(),
+                "cxx".to_string(),
+                "hxx".to_string(),
+            ],
             default_skip_dirs: vec!["build".to_string(), "obj".to_string(), "bin".to_string()],
             line_comment: "//".to_string(),
             block_comment_start: "/*".to_string(),
             block_comment_end: "*/".to_string(),
         }),
-        
+
         // 5. C#
         "csharp" | "c#" => Some(Language {
             extensions: vec!["cs".to_string()],
-            default_skip_dirs: vec!["bin".to_string(), "obj".to_string(), "Debug".to_string(), "Release".to_string()],
+            default_skip_dirs: vec![
+                "bin".to_string(),
+                "obj".to_string(),
+                "Debug".to_string(),
+                "Release".to_string(),
+            ],
             line_comment: "//".to_string(),
             block_comment_start: "/*".to_string(),
             block_comment_end: "*/".to_string(),
         }),
-        
+
         // 6. PHP
         "php" => Some(Language {
             extensions: vec!["php".to_string()],
@@ -67,7 +88,7 @@ fn get_language_config(lang: &str) -> Option<Language> {
             block_comment_start: "/*".to_string(),
             block_comment_end: "*/".to_string(),
         }),
-        
+
         // 7. Ruby
         "ruby" => Some(Language {
             extensions: vec!["rb".to_string()],
@@ -76,7 +97,7 @@ fn get_language_config(lang: &str) -> Option<Language> {
             block_comment_start: "=begin".to_string(),
             block_comment_end: "=end".to_string(),
         }),
-        
+
         // 8. Swift
         "swift" => Some(Language {
             extensions: vec!["swift".to_string()],
@@ -85,16 +106,20 @@ fn get_language_config(lang: &str) -> Option<Language> {
             block_comment_start: "/*".to_string(),
             block_comment_end: "*/".to_string(),
         }),
-        
+
         // 9. TypeScript
         "typescript" | "ts" => Some(Language {
             extensions: vec!["ts".to_string(), "tsx".to_string()],
-            default_skip_dirs: vec!["node_modules".to_string(), "dist".to_string(), "build".to_string()],
+            default_skip_dirs: vec![
+                "node_modules".to_string(),
+                "dist".to_string(),
+                "build".to_string(),
+            ],
             line_comment: "//".to_string(),
             block_comment_start: "/*".to_string(),
             block_comment_end: "*/".to_string(),
         }),
-        
+
         // 10. Kotlin
         "kotlin" | "kt" => Some(Language {
             extensions: vec!["kt".to_string(), "kts".to_string()],
@@ -103,7 +128,7 @@ fn get_language_config(lang: &str) -> Option<Language> {
             block_comment_start: "/*".to_string(),
             block_comment_end: "*/".to_string(),
         }),
-        
+
         // 11. Go
         "go" => Some(Language {
             extensions: vec!["go".to_string()],
@@ -112,7 +137,7 @@ fn get_language_config(lang: &str) -> Option<Language> {
             block_comment_start: "/*".to_string(),
             block_comment_end: "*/".to_string(),
         }),
-        
+
         // 12. Rust
         "rust" => Some(Language {
             extensions: vec!["rs".to_string()],
@@ -121,7 +146,7 @@ fn get_language_config(lang: &str) -> Option<Language> {
             block_comment_start: "/*".to_string(),
             block_comment_end: "*/".to_string(),
         }),
-        
+
         // 13. R
         "r" => Some(Language {
             extensions: vec!["r".to_string(), "R".to_string()],
@@ -130,7 +155,7 @@ fn get_language_config(lang: &str) -> Option<Language> {
             block_comment_start: "".to_string(), // R doesn't have traditional block comments
             block_comment_end: "".to_string(),
         }),
-        
+
         // 14. MATLAB
         "matlab" => Some(Language {
             extensions: vec!["m".to_string()],
@@ -139,7 +164,7 @@ fn get_language_config(lang: &str) -> Option<Language> {
             block_comment_start: "%{".to_string(),
             block_comment_end: "%}".to_string(),
         }),
-        
+
         // 15. VB.NET
         "vbnet" | "vb" => Some(Language {
             extensions: vec!["vb".to_string()],
@@ -148,7 +173,7 @@ fn get_language_config(lang: &str) -> Option<Language> {
             block_comment_start: "".to_string(), // VB.NET uses line comments primarily
             block_comment_end: "".to_string(),
         }),
-        
+
         // 16. Scala
         "scala" => Some(Language {
             extensions: vec!["scala".to_string()],
@@ -157,7 +182,7 @@ fn get_language_config(lang: &str) -> Option<Language> {
             block_comment_start: "/*".to_string(),
             block_comment_end: "*/".to_string(),
         }),
-        
+
         // 17. Perl
         "perl" => Some(Language {
             extensions: vec!["pl".to_string(), "pm".to_string()],
@@ -166,7 +191,7 @@ fn get_language_config(lang: &str) -> Option<Language> {
             block_comment_start: "=pod".to_string(),
             block_comment_end: "=cut".to_string(),
         }),
-        
+
         // 18. Dart
         "dart" => Some(Language {
             extensions: vec!["dart".to_string()],
@@ -175,7 +200,7 @@ fn get_language_config(lang: &str) -> Option<Language> {
             block_comment_start: "/*".to_string(),
             block_comment_end: "*/".to_string(),
         }),
-        
+
         // 19. Objective-C
         "objective-c" | "objc" => Some(Language {
             extensions: vec!["m".to_string(), "mm".to_string()],
@@ -184,16 +209,21 @@ fn get_language_config(lang: &str) -> Option<Language> {
             block_comment_start: "/*".to_string(),
             block_comment_end: "*/".to_string(),
         }),
-        
+
         // 20. Groovy
         "groovy" => Some(Language {
-            extensions: vec!["groovy".to_string(), "gvy".to_string(), "gy".to_string(), "gsh".to_string()],
+            extensions: vec![
+                "groovy".to_string(),
+                "gvy".to_string(),
+                "gy".to_string(),
+                "gsh".to_string(),
+            ],
             default_skip_dirs: vec!["target".to_string(), "build".to_string()],
             line_comment: "//".to_string(),
             block_comment_start: "/*".to_string(),
             block_comment_end: "*/".to_string(),
         }),
-        
+
         // 21. Julia
         "julia" => Some(Language {
             extensions: vec!["jl".to_string()],
@@ -202,7 +232,7 @@ fn get_language_config(lang: &str) -> Option<Language> {
             block_comment_start: "#=".to_string(),
             block_comment_end: "=#".to_string(),
         }),
-        
+
         // 22. Haskell
         "haskell" => Some(Language {
             extensions: vec!["hs".to_string(), "lhs".to_string()],
@@ -211,7 +241,7 @@ fn get_language_config(lang: &str) -> Option<Language> {
             block_comment_start: "{-".to_string(),
             block_comment_end: "-}".to_string(),
         }),
-        
+
         // 23. Shell/Bash
         "shell" | "bash" => Some(Language {
             extensions: vec!["sh".to_string(), "bash".to_string()],
@@ -220,7 +250,7 @@ fn get_language_config(lang: &str) -> Option<Language> {
             block_comment_start: "".to_string(), // Shell typically uses only line comments
             block_comment_end: "".to_string(),
         }),
-        
+
         // 24. Lua
         "lua" => Some(Language {
             extensions: vec!["lua".to_string()],
@@ -229,7 +259,7 @@ fn get_language_config(lang: &str) -> Option<Language> {
             block_comment_start: "--[[".to_string(),
             block_comment_end: "]]".to_string(),
         }),
-        
+
         // 25. C
         "c" => Some(Language {
             extensions: vec!["c".to_string(), "h".to_string()],
@@ -238,39 +268,51 @@ fn get_language_config(lang: &str) -> Option<Language> {
             block_comment_start: "/*".to_string(),
             block_comment_end: "*/".to_string(),
         }),
-        
+
         _ => None,
     }
 }
 
 fn should_skip(entry: &DirEntry, skip_dirs: &[String]) -> bool {
-    entry.path()
+    entry
+        .path()
         .file_name()
         .and_then(|n| n.to_str())
-        .map_or(false, |name| skip_dirs.contains(&name.to_string()))
+        .is_some_and(|name| skip_dirs.contains(&name.to_string()))
 }
 
 fn main() -> std::io::Result<()> {
     let args: Vec<String> = env::args().collect();
-    
+
     if args.len() < 3 {
-        eprintln!("Usage: {} <directory> --lang <language> [--skip dir1,dir2,dir3]", args[0]);
+        eprintln!(
+            "Usage: {} <directory> --lang <language> [--skip dir1,dir2,dir3]",
+            args[0]
+        );
         eprintln!("\nSupported languages:");
         eprintln!("  rust, go, c, cpp, python, javascript, typescript");
         std::process::exit(1);
     }
-    
+
     let target_dir = Path::new(&args[1]);
-    
+
     // Get language from arguments
-    let lang = args.iter()
+    let lang = args
+        .iter()
         .position(|arg| arg == "--lang")
         .and_then(|i| args.get(i + 1))
-        .expect("--lang argument is required");
-    
+        .unwrap_or_else(|| {
+            eprintln!("Error: --lang argument is required");
+            std::process::exit(1);
+        });
+
     let language_config = get_language_config(lang)
-        .expect("Unsupported language");
-    
+        .unwrap_or_else(|| {
+            eprintln!("Error: unsupported language '{}'", lang);
+            eprintln!("Supported: rust, go, c, cpp, python, javascript, typescript, java, csharp, php, ruby, swift, kotlin, scala, perl, dart, groovy, julia, haskell, shell, lua, r, matlab, vbnet, objective-c");
+            std::process::exit(1);
+        });
+
     // Combine default and user-specified skip directories
     let mut skip_dirs = language_config.default_skip_dirs;
     if let Some(pos) = args.iter().position(|arg| arg == "--skip") {
@@ -278,13 +320,14 @@ fn main() -> std::io::Result<()> {
             skip_dirs.extend(user_dirs.split(',').map(String::from));
         }
     }
-    
+
     // Create extension filter
-    let valid_extensions: HashMap<_, _> = language_config.extensions
+    let valid_extensions: HashMap<_, _> = language_config
+        .extensions
         .into_iter()
         .map(|ext| (ext, true))
         .collect();
-    
+
     for entry in WalkDir::new(target_dir)
         .into_iter()
         .filter_entry(|e| !should_skip(e, &skip_dirs))
@@ -293,17 +336,24 @@ fn main() -> std::io::Result<()> {
             e.path()
                 .extension()
                 .and_then(|ext| ext.to_str())
-                .map_or(false, |ext| valid_extensions.contains_key(ext))
+                .is_some_and(|ext| valid_extensions.contains_key(ext))
         })
     {
         let path = entry.path();
-        let content = fs::read_to_string(path)?;
-        let relative_path = path.strip_prefix(target_dir)
+        let relative_path = path
+            .strip_prefix(target_dir)
             .unwrap_or(path)
             .display()
             .to_string()
             .trim_start_matches('/')
             .to_string();
+        let content = match fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("Warning: skipping {}: {}", relative_path, e);
+                continue;
+            }
+        };
         let minified = minify(
             &content,
             &language_config.line_comment,
@@ -315,102 +365,113 @@ fn main() -> std::io::Result<()> {
     Ok(())
 }
 
+fn starts_with_at(chars: &[char], pos: usize, pattern: &[char]) -> bool {
+    if pattern.is_empty() || pos + pattern.len() > chars.len() {
+        return false;
+    }
+    chars[pos..pos + pattern.len()] == *pattern
+}
+
 fn minify(
     content: &str,
     line_comment: &str,
     block_comment_start: &str,
     block_comment_end: &str,
 ) -> String {
+    let chars: Vec<char> = content.chars().collect();
+    let lc: Vec<char> = line_comment.chars().collect();
+    let bcs: Vec<char> = block_comment_start.chars().collect();
+    let bce: Vec<char> = block_comment_end.chars().collect();
+    let n = chars.len();
+
     let mut result = String::with_capacity(content.len());
     let mut in_string = false;
     let mut in_char = false;
     let mut in_line_comment = false;
     let mut in_block_comment = false;
-    let mut prev_char = None;
-    let mut chars = content.chars().peekable();
-    
-    while let Some(c) = chars.next() {
-        match c {
-            '"' if !in_char && !in_line_comment && !in_block_comment => {
-                if prev_char != Some('\\') { in_string = !in_string; }
-                result.push(c);
+    let mut i = 0;
+
+    while i < n {
+        let c = chars[i];
+
+        // End line comment on newline
+        if in_line_comment {
+            if c == '\n' || c == '\r' {
+                in_line_comment = false;
             }
-            '\'' if !in_string && !in_line_comment && !in_block_comment => {
-                if prev_char != Some('\\') { in_char = !in_char; }
-                result.push(c);
-            }
-            _ if !in_string && !in_char && !in_line_comment && !in_block_comment => {
-                // Check for line comment start
-                if c == line_comment.chars().next().unwrap() {
-                    let mut is_line_comment = true;
-                    for expected in line_comment.chars().skip(1) {
-                        if chars.next() != Some(expected) {
-                            is_line_comment = false;
-                            break;
-                        }
-                    }
-                    if is_line_comment {
-                        in_line_comment = true;
-                        continue;
-                    }
-                }
-                
-                // Check for block comment start
-                if c == block_comment_start.chars().next().unwrap() {
-                    let mut is_block_start = true;
-                    for expected in block_comment_start.chars().skip(1) {
-                        if chars.next() != Some(expected) {
-                            is_block_start = false;
-                            break;
-                        }
-                    }
-                    if is_block_start {
-                        in_block_comment = true;
-                        continue;
-                    }
-                }
-                
-                // Check for block comment end
-                if in_block_comment && c == block_comment_end.chars().next().unwrap() {
-                    let mut is_block_end = true;
-                    for expected in block_comment_end.chars().skip(1) {
-                        if chars.next() != Some(expected) {
-                            is_block_end = false;
-                            break;
-                        }
-                    }
-                    if is_block_end {
-                        in_block_comment = false;
-                        continue;
-                    }
-                }
-                
-                if !c.is_whitespace() {
-                    result.push(c);
-                }
-            }
-            '\n' | '\r' => {
-                if in_line_comment {
-                    in_line_comment = false;
-                } else if in_string {
-                    result.push_str("\\n");
-                }
-            }
-            '\\' if in_string => {
-                result.push(c);
-                if let Some(&next) = chars.peek() {
-                    if matches!(next, 'n' | 'r' | 't' | '\\' | '"') {
-                        result.push(chars.next().unwrap());
-                    }
-                }
-            }
-            _ => {
-                if !in_line_comment && !in_block_comment && (!c.is_whitespace() || in_string || in_char) {
-                    result.push(c);
-                }
-            }
+            i += 1;
+            continue;
         }
-        prev_char = Some(c);
+
+        // End block comment when we see the closing sequence
+        if in_block_comment {
+            if starts_with_at(&chars, i, &bce) {
+                in_block_comment = false;
+                i += bce.len();
+            } else {
+                i += 1;
+            }
+            continue;
+        }
+
+        // Escape sequences inside string or char literals
+        if c == '\\' && (in_string || in_char) {
+            result.push(c);
+            if i + 1 < n {
+                result.push(chars[i + 1]);
+                i += 2;
+            } else {
+                i += 1;
+            }
+            continue;
+        }
+
+        // String delimiter
+        if c == '"' && !in_char {
+            in_string = !in_string;
+            result.push(c);
+            i += 1;
+            continue;
+        }
+
+        // Char/single-quote delimiter
+        if c == '\'' && !in_string {
+            in_char = !in_char;
+            result.push(c);
+            i += 1;
+            continue;
+        }
+
+        // Inside a string or char literal — preserve content
+        if in_string || in_char {
+            if c == '\n' || c == '\r' {
+                result.push_str("\\n");
+            } else {
+                result.push(c);
+            }
+            i += 1;
+            continue;
+        }
+
+        // Detect line comment start (checked before block comment so // wins over /*)
+        if starts_with_at(&chars, i, &lc) {
+            in_line_comment = true;
+            i += lc.len();
+            continue;
+        }
+
+        // Detect block comment start
+        if starts_with_at(&chars, i, &bcs) {
+            in_block_comment = true;
+            i += bcs.len();
+            continue;
+        }
+
+        // Normal character outside all comments and literals
+        if c != '\n' && c != '\r' && !c.is_whitespace() {
+            result.push(c);
+        }
+        i += 1;
     }
 
     result.split_whitespace().collect::<Vec<_>>().join(" ")


### PR DESCRIPTION
## Summary

- **Fix three bugs in `minify()`**: panic on empty comment strings (R/Shell/VB.NET), block comment end was dead code so block comments never closed, and iterator consumption bug that broke `/* */` detection for C-style languages
- **Improve error handling**: unknown `--lang` and unreadable files now warn/skip gracefully instead of panicking
- **Replace minimal `rust.yml`** with a full CI + release pipeline: fmt check, clippy (-D warnings), `cargo audit`, smoke test, 5-target matrix build (Linux x86\_64, Linux aarch64 via cross, macOS Intel, macOS Apple Silicon, Windows x86\_64), auto-versioned GitHub releases
- **Add `dependabot.yml`** for weekly Cargo and Actions updates

## Test plan

- [ ] CI job passes: fmt, clippy, audit, build, smoke test
- [ ] Build matrix produces all 5 platform binaries
- [ ] Release job tags and publishes binaries on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)